### PR TITLE
Avoid characters, which breake the use on Windows

### DIFF
--- a/run.py
+++ b/run.py
@@ -448,7 +448,7 @@ if __name__ == '__main__':
 	parser.add_argument('-config',          dest='config_dir',      default='./config/',            help='Config directory')
 	args = parser.parse_args()
 
-	if not args.restore: args.name = args.name + '_' + time.strftime('%d_%m_%Y') + '_' + time.strftime('%H:%M:%S')
+	if not args.restore: args.name = args.name + '_' + time.strftime('%d_%m_%Y') + '_' + time.strftime('%H_%M_%S')
 
 	set_gpu(args.gpu)
 	np.random.seed(args.seed)


### PR DESCRIPTION
When working with this repository one of the first issues we encountered, is that the code as is does not work on Windows. This little change allows to execute it on windows. As many people stumbled upon this fix (#36 ) it would make sense to change it.

Resolves #36